### PR TITLE
fix: use SUPERSET_HOST instead of superset

### DIFF
--- a/tutoroars/templates/oars/apps/pythonpath/superset-dashboard.py
+++ b/tutoroars/templates/oars/apps/pythonpath/superset-dashboard.py
@@ -10,7 +10,7 @@ from supersetapiclient.client import SupersetClient
 
 
 SUPERSET_URL_SCHEME = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}"
-SUPERSET_HOST_URL = f"{SUPERSET_URL_SCHEME}://superset:{{ SUPERSET_PORT }}"
+SUPERSET_HOST_URL = f"{SUPERSET_URL_SCHEME}://{{SUPERSET_HOST}}{% if not ENABLE_HTTPS %}:{{ SUPERSET_PORT }}{% endif %}"
 SUPERSET_ADMIN_USERNAME = "{{ SUPERSET_ADMIN_USERNAME }}"
 SUPERSET_ADMIN_PASSWORD = "{{ SUPERSET_ADMIN_PASSWORD }}"
 SUPERSET_DATA_ASSETS_DIR = "/app/oars/data/superset/"


### PR DESCRIPTION
## Description
This PR allow to use a superset running on HTTPS for on the init job. It also fixes a bug in which if HTTPS is enabled, the superset set host is never resolved and makes the `tutor local do init --limit oars` command to hang out.

## Testing instructions

- You can follow the instructions https://github.com/openedx/tutor-contrib-superset/pull/18.
- In the **config.yml** file, set ENABLE_HTTPS to true (point a real domain to the instance you are testing).
- Run `tutor config save`
- Run `tutor local do init --limit oars`

The command should work as expected, without this change the commands hang outs.