### PR TITLE
refactor: use patches instead programmatic declaration

### DIFF
--- a/tutoroars/patches/local-docker-compose-dev-jobs-services
+++ b/tutoroars/patches/local-docker-compose-dev-jobs-services
@@ -1,0 +1,9 @@
+oars-job:
+  user: root
+  image: python:3.8.10
+  volumes:
+    - ../../env/plugins/oars/apps:/app/oars
+  depends_on:
+    - superset
+    - clickhouse
+    - ralph

--- a/tutoroars/patches/local-docker-compose-jobs-services
+++ b/tutoroars/patches/local-docker-compose-jobs-services
@@ -1,0 +1,9 @@
+oars-job:
+  user: root
+  image: python:3.8.10
+  volumes:
+    - ../../env/plugins/oars/apps:/app/oars
+  depends_on:
+    - superset
+    - clickhouse
+    - ralph

--- a/tutoroars/plugin.py
+++ b/tutoroars/plugin.py
@@ -185,38 +185,6 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
 )
 
 
-# Initialization jobs
-OARS_DOCKER_COMPOSE_PYTHON_JOB = """
-  user: root
-  image: python:3.8.10
-  volumes:
-    - ../../env/plugins/oars/apps:/app/oars
-  depends_on:
-    - superset
-    - clickhouse
-    - ralph
-"""
-
-hooks.Filters.ENV_PATCHES.add_item(
-    (
-        "local-docker-compose-jobs-services",
-        f"""
-oars-job:
-  {OARS_DOCKER_COMPOSE_PYTHON_JOB}
-        """
-    )
-)
-
-hooks.Filters.ENV_PATCHES.add_item(
-    (
-        "local-docker-compose-dev-jobs-services",
-        f"""
-oars-job:
-  {OARS_DOCKER_COMPOSE_PYTHON_JOB}
-        """
-    )
-)
-
 ########################################
 # PATCH LOADING
 # (It is safe & recommended to leave


### PR DESCRIPTION
## Description
This PR moves the patches created programmatically in the plugin.py file into their patch files, which is the usual design followed by tutor plugins.

## How to test
You can follow the instructions [here](https://github.com/openedx/tutor-contrib-superset/pull/18).

## Authors concern
We found that the patch called `local-docker-compose-dev-jobs-services` doesn't exist according tutor's list of patches: https://docs.tutor.overhang.io/reference/patches.html. Should we use https://docs.tutor.overhang.io/reference/patches.html#dev-docker-compose-jobs-services instead?