### PR TITLE
build: remove unused static type checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Static code analysis
         run: make test-lint
 
-      # Enable when types annotations are fixed
-      # - name: Static type checks
-      #   run: make test-types
-
       - name: Code formatting
         run: make test-format
 


### PR DESCRIPTION
## Description

We are removing the static type checks as those don't add any real value