### PR TITLE
chore: pin event-routing-backends to 5.2.2

### DIFF
--- a/tutoroars/plugin.py
+++ b/tutoroars/plugin.py
@@ -37,8 +37,8 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         (
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
-                "edx-event-routing-backends",
                 "openedx-event-sink-clickhouse==0.1.0",
+                "edx-event-routing-backends==5.2.2",
             ],
         ),
     ]


### PR DESCRIPTION
## Description

This PR pins the version of event-routing-backends