### PR TITLE
fix: Upgrade event-routing-backends to 5.3.1

### DIFF
--- a/tutoroars/plugin.py
+++ b/tutoroars/plugin.py
@@ -40,7 +40,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             "OPENEDX_EXTRA_PIP_REQUIREMENTS",
             [
                 "openedx-event-sink-clickhouse==0.1.0",
-                "edx-event-routing-backends==5.3.0",
+                "edx-event-routing-backends==5.3.1",
             ],
         ),
     ]


### PR DESCRIPTION
- Fixes issues in the 5.3.0 release on pre-Palm edx-platform
- Fixes unnecessary retries on duplicate event id's 