### PR TITLE
fix: add missing bcrypt dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.7",
-    install_requires=["tutor"],
+    install_requires=["tutor", "bcrypt"],
     entry_points={"tutor.plugin.v1": ["oars = tutoroars.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Description

This PR adds a missing `bcrypt` dependency on install