### PR TITLE
feat: create high-level MVs and backing tables (FC-0024)

### DIFF
--- a/tutoroars/plugin.py
+++ b/tutoroars/plugin.py
@@ -30,8 +30,15 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("OARS_RAW_XAPI_TABLE", "xapi_events_all"),
         ("OARS_XAPI_TRANSFORM_MV", "xapi_events_all_parsed_mv"),
         ("OARS_XAPI_TABLE", "xapi_events_all_parsed"),
+        # ClickHouse top-level materialized views
         ("OARS_ENROLLMENT_TRANSFORM_MV", "enrollment_events_mv"),
         ("OARS_ENROLLMENT_EVENTS_TABLE", "enrollment_events"),
+        ("OARS_VIDEO_PLAYBACK_TRANSFORM_MV", "video_playback_events_mv"),
+        ("OARS_VIDEO_PLAYBACK_EVENTS_TABLE", "video_playback_events"),
+        ("OARS_PROBLEM_TRANSFORM_MV", "problem_events_mv"),
+        ("OARS_PROBLEM_EVENTS_TABLE", "problem_events"),
+        ("OARS_NAVIGATION_TRANSFORM_MV", "navigation_events_mv"),
+        ("OARS_NAVIGATION_EVENTS_TABLE", "navigation_events"),
         # ClickHouse event sink settings
         ("OARS_EVENT_SINK_DATABASE", "event_sink"),
         ("OARS_EVENT_SINK_NODES_TABLE", "course_blocks"),


### PR DESCRIPTION
PR for [issue #58 ](https://github.com/openedx/tutor-contrib-oars/issues/58)

Creates tables for:
- video playback events
- problem interaction events
- navigation events

The `problem_events` table omits the browser's `problem_check` event from the `problem_events` table. There is a note in the code, but this was primarily because from what I can tell there's nothing in the browser events that isn't in the server events. During my testing, I only came across one instance where browser events where sent without an accompanying server event, and that was when there was a server error (something about my development environment must not be fully set up properly). As a corollary to this, we save a considerable amount of space by only keeping the server events.

I'd love some feedback on the naming conventions, included attributes, and data types, in addition to anything else that might cross your mind.