### PR TITLE
feat: Adds language configuration options for Superset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,34 @@ To contribute assets to OARS:
 .. _assets directory: https://github.com/openedx/tutor-contrib-oars/tree/main/tutoroars/templates/oars/apps/data/assets
 
 
+Changing Superset Language Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Superset localization is a work in progress, but you can change the default language and set alternate languages from the currently supported list by changing the Tutor configuration variables:
+
+Default language: ``tutor config save --set SUPERSET_DEFAULT_LOCALE=en``
+
+Available languages are stored in a mapping, and so best edited directly in Tutor's config.yml file. You can find the path to the config file with ``tutor config printroot``. Once there, you can set the SUPERSET_SUPPORTED_LANGUAGES with a mapping of the following structure::
+
+    SUPERSET_SUPPORTED_LANGUAGES: {
+        "en": {"flag": "us", "name": "English"},
+        "es": {"flag": "es", "name": "Spanish"},
+        "it": {"flag": "it", "name": "Italian"},
+        "fr": {"flag": "fr", "name": "French"},
+        "zh": {"flag": "cn", "name": "Chinese"},
+        "ja": {"flag": "jp", "name": "Japanese"},
+        "de": {"flag": "de", "name": "German"},
+        "pt": {"flag": "pt", "name": "Portuguese"},
+        "pt_BR": {"flag": "br", "name": "Brazilian Portuguese"},
+        "ru": {"flag": "ru", "name": "Russian"},
+        "ko": {"flag": "kr", "name": "Korean"},
+        "sk": {"flag": "sk", "name": "Slovak"},
+        "sl": {"flag": "si", "name": "Slovenian"},
+        "nl": {"flag": "nl", "name": "Dutch"},
+    }
+
+Where the first key is the abbreviation of the language to use, "flag" is which flag icon is displayed in the user interface for choosing the language, and "name" is the displayed name for that language. The mapping above shows all of the current languages supported by Superset, but please note that different languages have different levels of completion and support at this time.
+
 License
 -------
 

--- a/tutoroars/plugin.py
+++ b/tutoroars/plugin.py
@@ -142,6 +142,14 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
             },
         ),
         ("SUPERSET_TALISMAN_ENABLED", True),
+        ("SUPERSET_DEFAULT_LOCALE", "en"),
+        (
+            "SUPERSET_SUPPORTED_LANGUAGES",
+            {
+                "en": {"flag": "us", "name": "English"},
+                "es": {"flag": "es", "name": "Spanish"},
+            },
+        ),
     ]
 )
 

--- a/tutoroars/templates/oars/apps/superset/pythonpath/superset_config.py
+++ b/tutoroars/templates/oars/apps/superset/pythonpath/superset_config.py
@@ -147,6 +147,10 @@ TALISMAN_ENABLED = {{SUPERSET_TALISMAN_ENABLED}}
 TALISMAN_CONFIG = {{SUPERSET_TALISMAN_CONFIG}}
 {% endif %}
 #
+
+BABEL_DEFAULT_LOCALE = "{{ SUPERSET_DEFAULT_LOCALE }}"
+LANGUAGES = {{ SUPERSET_SUPPORTED_LANGUAGES }}
+
 # Optionally import superset_config_docker.py (which will have been included on
 # the PYTHONPATH) in order to allow for local settings to be overridden
 #


### PR DESCRIPTION
Allows setting a default language and list of supported languages in Superset. Superset localization seems to be in a fairly poor state, but it's a thing we can help with. This enables us to start testing.

![Screenshot 2023-06-21 at 10 13 13 AM](https://github.com/openedx/tutor-contrib-oars/assets/112640379/7cdcc21b-7943-459a-b5d5-1df6ac32d8ff)

![Screenshot 2023-06-21 at 10 31 18 AM](https://github.com/openedx/tutor-contrib-oars/assets/112640379/6335b949-8bcf-41c6-a129-15b16b31bd59)
