### PR TITLE
feat!: prefer verb_id for primary key in event MVs (FC-0024)

### DIFF
--- a/tutoroars/templates/oars/jobs/init/clickhouse/oars_init_schemas_tables_users.sh
+++ b/tutoroars/templates/oars/jobs/init/clickhouse/oars_init_schemas_tables_users.sh
@@ -87,8 +87,8 @@ CREATE TABLE IF NOT EXISTS {{ OARS_XAPI_DATABASE }}.{{ OARS_ENROLLMENT_EVENTS_TA
     `verb_id` LowCardinality(String) NOT NULL,
     `enrollment_mode` LowCardinality(String)
 ) ENGINE = MergeTree
-PRIMARY KEY (org, course_id, enrollment_mode)
-ORDER BY (org, course_id, enrollment_mode, emission_time);
+PRIMARY KEY (org, course_id)
+ORDER BY (org, course_id, actor_id, enrollment_mode, emission_time);
 
 -- Materialized view that moves data from the processed xAPI table to
 -- the enrollment events table


### PR DESCRIPTION
Removes `event_type` from top-level event MVs and changes the data type of `verb_id` to `LowCardinality(String)`. As a result of the removal, the MV tables now use `verb_id` in the primary key instead of `event_type`. The data type change should be transparent to users of these tables while improving performance.

I've tested this by running `tutor local do init --limit oars` using my local copy of the repo and confirmed data can still be inserted via `tutor local do load-xapi-test-data`.